### PR TITLE
Add Implementation-Version to manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ allprojects {
 
 jar {
     baseName = 'ambari-shell'
+    manifest {
+        attributes(
+            "Implementation-Version": "${version ?: 'dev'}",
+        )
+    }
 }
 
 configurations {


### PR DESCRIPTION
Fixes #37 (for subsequent builds)

```bash
$ ./gradlew clean build && java -jar build/libs/ambari-shell-*jar --ambari.host=localhost <<EOF
version
EOF
...
BUILD SUCCESSFUL
...
ambari-shell>version
0.1.DEV.37_version_command_returns_nothing
```